### PR TITLE
Add CredentialPolicy base format

### DIFF
--- a/lightning-htlc-scorer/src/common/msgs.rs
+++ b/lightning-htlc-scorer/src/common/msgs.rs
@@ -1,0 +1,35 @@
+// This file is Copyright its original authors, visibile in version control
+// history.
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE
+// or http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT> or http://opensource.org/licenses/MIT>, at your option.
+// You may not use this file except in accordance with one or both of these
+// licenses.
+
+//! A new BOLT7 gossip message CredentialPolicy to announce one's liquidity
+//! risk-management policy to the rest of the Lightning network.
+//!
+//! The policy has a timestamp, a list of accepted asset proofs, a list of accepted
+//! credentials, the `asset-to-credential` ratio and the expiration height of
+//! credentials if any.
+//!
+//! A list of `credentials-to-liquidity-unit` per-Contract-Provider covered can
+//! be attached.
+
+/// The unsigned part of a credential_policy message.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UnsignedCredentialPolicy {
+	pub timestamp: u32,
+	pub asset_proof: AssetProofFeatures,
+	pub credentials: CredentialsFeatures,
+	pub asset_to_credential: u32,
+	pub expiration_height: u32,
+}
+
+/// A credential_policy message to be sent or received from a peer.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CredentialPolicy {
+	pub signature: Signature,
+	pub contents: UnsignedCredentialPolicy,
+}


### PR DESCRIPTION
The `CredentialPolicy` should announce the `credential-to-liquidity-unit` for each ContractProvider covered. Likely should attach a list of ratio per-contract covered (time value risk isn't same across all your ContractProvider, and contract types, dual-funding != HTLC forward). There is the assumption Issuer and set of ContractProviders are deployed by the same entity so internal credentials signing key management shouldn't be an issue. ContractProvider shouldn't have to announce their own policy.